### PR TITLE
Changed pixels_by_color array to have strings as keys.

### DIFF
--- a/web/robot/procedure_line_injector.py
+++ b/web/robot/procedure_line_injector.py
@@ -162,8 +162,8 @@ class ProcedureLineInjector:
                     units_per_mm = 1 / well_radius
                 )
                 if color_block.color_id not in pixels_by_color:
-                    pixels_by_color[color_block.color_id] = dict()
-                pixels_by_color[color_block.color_id][artpiece.slug] = pixel_list
+                    pixels_by_color[str(color_block.color_id)] = dict()
+                pixels_by_color[str(color_block.color_id)][artpiece.slug] = pixel_list
         procedure = template_string.replace('%%PIXELS GO HERE%%', str(pixels_by_color))
         return procedure
 


### PR DESCRIPTION
Within the protocols generated it looks like there is inconsistency between the keys in pixels_by_color_by_artpiece and color_map. pixels_by_color_by_artpiece had integer keys, color_map had string keys. In previous protocols generated pixels_by_color_by_artpiece has string keys, so this PR changes back to that format. (I think. No unit tests have been created for this functionality yet)